### PR TITLE
[Feat] #41 - 경험 상세페이지 API 연결 및 MVVM 구조로 리팩토링

### DIFF
--- a/ShallWe/ShallWe.xcodeproj/project.pbxproj
+++ b/ShallWe/ShallWe.xcodeproj/project.pbxproj
@@ -161,6 +161,10 @@
 		A431BE5E2B1AFAF90049C126 /* UICollectionViewRegisterable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A431BE5D2B1AFAF90049C126 /* UICollectionViewRegisterable.swift */; };
 		A431BE602B1AFB160049C126 /* UITableViewRegisterable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A431BE5F2B1AFB160049C126 /* UITableViewRegisterable.swift */; };
 		A431BE772B1EEF4A0049C126 /* ExperienceGiftViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A431BE762B1EEF4A0049C126 /* ExperienceGiftViewController.swift */; };
+		A4998BC72B761CB200883017 /* ExperienceDetailResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4998BC62B761CB200883017 /* ExperienceDetailResponseDto.swift */; };
+		A4998BCA2B778C6B00883017 /* ExperienceDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4998BC92B778C6B00883017 /* ExperienceDetailViewModel.swift */; };
+		A4998BCD2B77967B00883017 /* ExperienceTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4998BCC2B77967B00883017 /* ExperienceTarget.swift */; };
+		A4998BD02B77981600883017 /* ExperienceAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4998BCF2B77981600883017 /* ExperienceAPI.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -304,6 +308,10 @@
 		A431BE762B1EEF4A0049C126 /* ExperienceGiftViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceGiftViewController.swift; sourceTree = "<group>"; };
 		A4998BC32B760B2400883017 /* ConfigDev.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ConfigDev.xcconfig; sourceTree = "<group>"; };
 		A4998BC42B760B9800883017 /* ConfigRelease.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ConfigRelease.xcconfig; sourceTree = "<group>"; };
+		A4998BC62B761CB200883017 /* ExperienceDetailResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceDetailResponseDto.swift; sourceTree = "<group>"; };
+		A4998BC92B778C6B00883017 /* ExperienceDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceDetailViewModel.swift; sourceTree = "<group>"; };
+		A4998BCC2B77967B00883017 /* ExperienceTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceTarget.swift; sourceTree = "<group>"; };
+		A4998BCF2B77981600883017 /* ExperienceAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceAPI.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -419,6 +427,7 @@
 		032212DF2B14B00B00FF5CF1 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				A4998BC52B761BA700883017 /* Experience */,
 				03A6A5E12B7600AD007B24E4 /* Home */,
 				032212E02B14B01F00FF5CF1 /* DTO.swift */,
 			);
@@ -439,6 +448,7 @@
 		032212E32B14B04600FF5CF1 /* API */ = {
 			isa = PBXGroup;
 			children = (
+				A4998BCE2B77980800883017 /* Experience */,
 				032213142B14B2EA00FF5CF1 /* API.swift */,
 			);
 			path = API;
@@ -565,6 +575,7 @@
 		0322131E2B14B73500FF5CF1 /* APIService */ = {
 			isa = PBXGroup;
 			children = (
+				A4998BCB2B77965D00883017 /* Experience */,
 				0322131F2B14B75100FF5CF1 /* APIService.swift */,
 			);
 			path = APIService;
@@ -985,6 +996,7 @@
 			children = (
 				A42C32542B26C68700C4B477 /* Cell */,
 				A42C32532B26C68300C4B477 /* View */,
+				A4998BC82B778BE500883017 /* ViewModel */,
 				A42C32522B26C67E00C4B477 /* ViewController */,
 			);
 			path = ExperienceDetail;
@@ -1085,6 +1097,38 @@
 				A42C33682B416B3E00C4B477 /* TimeCollectionViewCell.swift */,
 			);
 			path = Cell;
+			sourceTree = "<group>";
+		};
+		A4998BC52B761BA700883017 /* Experience */ = {
+			isa = PBXGroup;
+			children = (
+				A4998BC62B761CB200883017 /* ExperienceDetailResponseDto.swift */,
+			);
+			path = Experience;
+			sourceTree = "<group>";
+		};
+		A4998BC82B778BE500883017 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				A4998BC92B778C6B00883017 /* ExperienceDetailViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		A4998BCB2B77965D00883017 /* Experience */ = {
+			isa = PBXGroup;
+			children = (
+				A4998BCC2B77967B00883017 /* ExperienceTarget.swift */,
+			);
+			path = Experience;
+			sourceTree = "<group>";
+		};
+		A4998BCE2B77980800883017 /* Experience */ = {
+			isa = PBXGroup;
+			children = (
+				A4998BCF2B77981600883017 /* ExperienceAPI.swift */,
+			);
+			path = Experience;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1231,14 +1275,17 @@
 				034011412B5CD87C00D1F371 /* SortModel.swift in Sources */,
 				95748DDE2B358190004157E0 /* ProfileEntryView.swift in Sources */,
 				95748DE02B359802004157E0 /* CustomButton.swift in Sources */,
+				A4998BD02B77981600883017 /* ExperienceAPI.swift in Sources */,
 				A42C33672B416AE300C4B477 /* ExperienceGiftView.swift in Sources */,
 				A431BE552B1A24F90049C126 /* (null) in Sources */,
 				95748DDE2B358190004157E0 /* ProfileEntryView.swift in Sources */,
 				9515EF682B5421AE00C4E1AA /* TermsDetailsPopUpViewController.swift in Sources */,
 				9515EF662B51600800C4E1AA /* AgreementOfTermsView.swift in Sources */,
 				032212F12B14B17600FF5CF1 /* MakeVibrate.swift in Sources */,
+				A4998BC72B761CB200883017 /* ExperienceDetailResponseDto.swift in Sources */,
 				0322130B2B14B25900FF5CF1 /* UIStackView+.swift in Sources */,
 				A431BE772B1EEF4A0049C126 /* ExperienceGiftViewController.swift in Sources */,
+				A4998BCA2B778C6B00883017 /* ExperienceDetailViewModel.swift in Sources */,
 				A42C33692B416B3E00C4B477 /* TimeCollectionViewCell.swift in Sources */,
 				A431BE582B1A25180049C126 /* (null) in Sources */,
 				0345806D2B288104002DDEBA /* HomeExperienceViewModel.swift in Sources */,
@@ -1294,6 +1341,7 @@
 				95748DD82B2D9D86004157E0 /* SignUpCompletionViewController.swift in Sources */,
 				032213B52B241B3100FF5CF1 /* HomeView.swift in Sources */,
 				032212E12B14B01F00FF5CF1 /* DTO.swift in Sources */,
+				A4998BCD2B77967B00883017 /* ExperienceTarget.swift in Sources */,
 				954E45BC2B20AEBE00D12242 /* AuthHeaderView.swift in Sources */,
 				032213192B14B30A00FF5CF1 /* Config.swift in Sources */,
 				9515EF8C2B6593FB00C4E1AA /* MemoryPhotoAlbumView.swift in Sources */,

--- a/ShallWe/ShallWe/Data/Experience/ExperienceDetailResponseDto.swift
+++ b/ShallWe/ShallWe/Data/Experience/ExperienceDetailResponseDto.swift
@@ -1,0 +1,31 @@
+//
+//  ExperienceDetailResponseDto.swift
+//  ShallWe
+//
+//  Created by 고아라 on 2/9/24.
+//
+
+struct ExperienceDetailResponseDto: Codable {
+    let giftImgURL: [String]
+    let title, subtitle: String
+    let price: Int
+    let explanation: [Explanation]
+    let description, location: String
+    let experienceGiftID: Int
+
+    enum CodingKeys: String, CodingKey {
+        case giftImgURL = "giftImgUrl"
+        case title, subtitle, price, explanation, description, location
+        case experienceGiftID = "experienceGiftId"
+    }
+}
+
+struct Explanation: Codable {
+    let stage, description: String
+    let explanationURL: String
+
+    enum CodingKeys: String, CodingKey {
+        case stage, description
+        case explanationURL = "explanationUrl"
+    }
+}

--- a/ShallWe/ShallWe/Network/API/Experience/ExperienceAPI.swift
+++ b/ShallWe/ShallWe/Network/API/Experience/ExperienceAPI.swift
@@ -1,0 +1,41 @@
+//
+//  ExperienceAPI.swift
+//  ShallWe
+//
+//  Created by 고아라 on 2/10/24.
+//
+
+import Foundation
+
+import Moya
+
+final class ExperienceAPI {
+    
+    static let shared: ExperienceAPI = ExperienceAPI()
+    
+    private let experienceProvider = MoyaProvider<ExperienceTarget>(plugins: [NetworkLoggerPlugin()])
+    
+    private init() {}
+    
+    public private(set) var experienceDetailData: GeneralResponse<ExperienceDetailResponseDto>?
+    
+    func getExperienceDetail(giftId: Int,
+                             completion: @escaping(GeneralResponse<ExperienceDetailResponseDto>?) -> Void) {
+        experienceProvider.request(.getExperienceDetail(experienceGiftId: giftId)) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let response):
+                do {
+                    self.experienceDetailData = try response.map(GeneralResponse<ExperienceDetailResponseDto>?.self)
+                    guard let experienceDetailData = self.experienceDetailData else { return }
+                    completion(experienceDetailData)
+                } catch let err {
+                    print(err.localizedDescription)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
+}

--- a/ShallWe/ShallWe/Network/APIService/Experience/ExperienceTarget.swift
+++ b/ShallWe/ShallWe/Network/APIService/Experience/ExperienceTarget.swift
@@ -1,0 +1,47 @@
+//
+//  ExperienceTarget.swift
+//  ShallWe
+//
+//  Created by 고아라 on 2/10/24.
+//
+
+import Foundation
+
+import Moya
+
+enum ExperienceTarget {
+    case getExperienceDetail(experienceGiftId: Int)
+}
+
+extension ExperienceTarget: TargetType {
+    var baseURL: URL {
+        return URL(string: URLConstant.baseURL)!
+    }
+    
+    var path: String {
+        switch self {
+        case .getExperienceDetail(experienceGiftId: let experienceGiftId):
+            let path = URLConstant.experienceDetails
+                .replacingOccurrences(of: "{ExperienceGiftId}", with: String(experienceGiftId))
+            return path
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getExperienceDetail:
+            return .get
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .getExperienceDetail:
+            return .requestPlain
+        }
+    }
+    
+    var headers: [String : String]? {
+        return APIConstants.headerWithAuthorization
+    }
+}

--- a/ShallWe/ShallWe/Network/APIService/Experience/ExperienceTarget.swift
+++ b/ShallWe/ShallWe/Network/APIService/Experience/ExperienceTarget.swift
@@ -13,11 +13,8 @@ enum ExperienceTarget {
     case getExperienceDetail(experienceGiftId: Int)
 }
 
-extension ExperienceTarget: TargetType {
-    var baseURL: URL {
-        return URL(string: URLConstant.baseURL)!
-    }
-    
+extension ExperienceTarget: BaseTargetType {
+
     var path: String {
         switch self {
         case .getExperienceDetail(experienceGiftId: let experienceGiftId):

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/Cell/ExperienceImageCollectionViewCell.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/Cell/ExperienceImageCollectionViewCell.swift
@@ -8,13 +8,13 @@
 import UIKit
 
 import SnapKit
+import Kingfisher
 
 final class ExperienceImageCollectionViewCell: UICollectionViewCell, UICollectionViewRegisterable {
     
     private let imageView: UIImageView = {
         let image = UIImageView()
         image.contentMode = .scaleAspectFill
-        image.image = UIImage(named: "example")
         return image
     }()
     
@@ -32,7 +32,8 @@ final class ExperienceImageCollectionViewCell: UICollectionViewCell, UICollectio
     }
 }
 
-extension ExperienceImageCollectionViewCell {
+private extension ExperienceImageCollectionViewCell {
+    
     func setHierarchy() {
         addSubview(imageView)
     }
@@ -41,5 +42,12 @@ extension ExperienceImageCollectionViewCell {
         imageView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
+    }
+}
+
+extension ExperienceImageCollectionViewCell{
+    
+    func configureCell(img: String) {
+        imageView.kf.setImage(with: URL(string: img))
     }
 }

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/Cell/ExplainTableViewCell.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/Cell/ExplainTableViewCell.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import SnapKit
+import Kingfisher
 
 final class ExplainTableViewCell: UITableViewCell, UITableViewRegisterable {
     
@@ -66,9 +67,10 @@ final class ExplainTableViewCell: UITableViewCell, UITableViewRegisterable {
     }
 }
 
-extension ExplainTableViewCell {
+private extension ExplainTableViewCell {
+    
     func setUI() {
-        backgroundColor = .bg0
+        backgroundColor = .white
     }
     
     func setHierarchy() {
@@ -109,3 +111,22 @@ extension ExplainTableViewCell {
     }
 }
 
+
+extension ExplainTableViewCell {
+    
+    func configureCell(model: Explanation) {
+        explainTitle.text = model.stage
+        explainImage.kf.setImage(with: URL(string: model.explanationURL))
+        explainSubTitle.text = model.description
+        explainImage.isHidden = false
+        explainSubTitle.isHidden = false
+        lineView.isHidden = false
+    }
+    
+    func configureLastCell() {
+        explainTitle.text = "완성"
+        explainImage.isHidden = true
+        explainSubTitle.isHidden = true
+        lineView.isHidden = true
+    }
+}

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/ExperienceDetailView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/ExperienceDetailView.swift
@@ -111,7 +111,7 @@ final class ExperienceDetailView: UIView {
         return view
     }()
     
-    private lazy var gifButton: UIButton = {
+    lazy var gifButton: UIButton = {
         let button = UIButton()
         button.setImage(ImageLiterals.Icon.gift, for: .normal)
         button.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 15)

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/ExperienceDetailView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/ExperienceDetailView.swift
@@ -141,7 +141,7 @@ final class ExperienceDetailView: UIView {
 // MARK: - Extensions
 extension ExperienceDetailView {
     func setUI() {
-        backgroundColor = .bg0
+        backgroundColor = .white
     }
     
     func setHierarchy() {

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/ExperienceDetailView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/ExperienceDetailView.swift
@@ -16,6 +16,13 @@ final class ExperienceDetailView: UIView {
     let explainDetailView = ExplainDetailView()
     private let guideDetailView = GuideDetailView()
     
+    let navigationBar: CustomNavigationBar = {
+        let nav = CustomNavigationBar()
+        nav.isLogoViewIncluded = true
+        nav.isBackButtonIncluded = true
+        return nav
+    }()
+    
     private let scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.showsVerticalScrollIndicator = false
@@ -145,12 +152,18 @@ extension ExperienceDetailView {
     }
     
     func setHierarchy() {
-        self.addSubviews(gifButton, scrollView)
+        self.addSubviews(navigationBar, gifButton, scrollView)
         scrollView.addSubviews(contentView)
         contentView.addSubviews(imageCollectionView, experienceTitle, experienceSubTitle, priceLabel, seperatorView, segmentControl, underLineView, guideDetailView, explainDetailView)
     }
     
     func setLayout() {
+        navigationBar.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(50)
+        }
+        
         gifButton.snp.makeConstraints {
             $0.bottom.equalTo(safeAreaLayoutGuide).offset(-36)
             $0.leading.equalToSuperview().inset(15)
@@ -159,7 +172,7 @@ extension ExperienceDetailView {
         }
         
         scrollView.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide)
+            $0.top.equalTo(navigationBar.snp.bottom).offset(13)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(gifButton.snp.top)
         }

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/ExperienceDetailView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/ExperienceDetailView.swift
@@ -50,7 +50,6 @@ final class ExperienceDetailView: UIView {
     
     private let experienceTitle: UILabel = {
         let label = UILabel()
-        label.text = "[성수] 인기베이킹 클래스"
         label.textColor = .black0
         label.font = .fontGuide(.SB00_14)
         return label
@@ -58,7 +57,6 @@ final class ExperienceDetailView: UIView {
     
     private let experienceSubTitle: UILabel = {
         let label = UILabel()
-        label.text = "기념일 레터링 케이크\n사지 말고 함께 만들어요"
         label.textColor = .black
         label.font = .fontGuide(.SB00_16_23)
         label.setLineSpacing(lineSpacing: 2.3)
@@ -68,10 +66,8 @@ final class ExperienceDetailView: UIView {
     
     private let priceLabel: UILabel = {
         let label = UILabel()
-        label.text = "75,000원"
         label.textColor = .main
         label.font = .fontGuide(.B00_20)
-        label.partFontChange(targetString: "원", font: .fontGuide(.B00_14))
         return label
     }()
     
@@ -146,7 +142,8 @@ final class ExperienceDetailView: UIView {
 }
 
 // MARK: - Extensions
-extension ExperienceDetailView {
+private extension ExperienceDetailView {
+    
     func setUI() {
         backgroundColor = .white
     }
@@ -206,7 +203,7 @@ extension ExperienceDetailView {
         }
         
         seperatorView.snp.makeConstraints {
-            $0.top.equalTo(experienceSubTitle.snp.bottom).offset(16)
+            $0.top.equalTo(priceLabel.snp.bottom).offset(16)
             $0.leading.trailing.equalToSuperview().inset(7)
             $0.height.equalTo(1)
         }
@@ -267,5 +264,21 @@ extension ExperienceDetailView {
             self.underLineView.snp.updateConstraints { $0.leading.equalTo(self.segmentControl.snp.leading).offset(leadingDistance) }
             self.layoutIfNeeded()
         })
+    }
+    
+    func formatNumber(_ number: Int) -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        return numberFormatter.string(from: NSNumber(value: number)) ?? "\(number)"
+    }
+}
+
+extension ExperienceDetailView {
+    
+    func configureExperienceView(model: ExperienceDetailResponseDto) {
+        experienceTitle.text = model.subtitle
+        experienceSubTitle.text = model.title
+        priceLabel.text = "\(formatNumber(model.price))원"
+        priceLabel.partFontChange(targetString: "원", font: .fontGuide(.B00_14))
     }
 }

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/ExplainDetailView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/ExplainDetailView.swift
@@ -15,7 +15,6 @@ final class ExplainDetailView: UIView {
     
     private let explainDetailLabel: UILabel = {
         let label = UILabel()
-        label.text = "기념일에 없으면 섭섭한 레터링 케이크\n\n그냥 주고받을때도 물론 기쁘지만,\n직접 만들 떄는 두 배로 즐거워요!"
         label.textColor = .black
         label.font = .fontGuide(.R00_14)
         label.numberOfLines = 0
@@ -52,7 +51,6 @@ final class ExplainDetailView: UIView {
     
     private let addressLabel: UILabel = {
         let label = UILabel()
-        label.text = "서울특별시 성동구 00로 12-34 2층"
         label.textColor = .black
         label.font = .fontGuide(.R00_14)
         return label
@@ -75,7 +73,8 @@ final class ExplainDetailView: UIView {
     }
 }
 
-extension ExplainDetailView {
+private extension ExplainDetailView {
+    
     func setUI() {
         backgroundColor = .white
     }
@@ -116,5 +115,13 @@ extension ExplainDetailView {
     
     func setRegisterCell() {
         ExplainTableViewCell.register(tableView: explainTableView)
+    }
+}
+
+extension ExplainDetailView {
+    
+    func configureExplainView(model: ExperienceDetailResponseDto) {
+        explainDetailLabel.text = model.description
+        addressLabel.text = model.location
     }
 }

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/ExplainDetailView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/ExplainDetailView.swift
@@ -32,7 +32,7 @@ final class ExplainDetailView: UIView {
     
     lazy var explainTableView: UITableView = {
         lazy var tableView = UITableView(frame: .zero, style: .plain)
-        tableView.backgroundColor = .bg0
+        tableView.backgroundColor = .white
         tableView.sectionFooterHeight = 0
         tableView.sectionHeaderTopPadding = 0
         tableView.isScrollEnabled = false
@@ -77,7 +77,7 @@ final class ExplainDetailView: UIView {
 
 extension ExplainDetailView {
     func setUI() {
-        backgroundColor = .bg0
+        backgroundColor = .white
     }
     
     func setHierarchy() {
@@ -99,7 +99,7 @@ extension ExplainDetailView {
         explainTableView.snp.makeConstraints {
             $0.top.equalTo(tableViewTitle.snp.bottom).offset(18)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(450)
+            $0.height.equalTo(417)
         }
         
         addressTitle.snp.makeConstraints {

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/GuideDetailView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/GuideDetailView.swift
@@ -82,7 +82,7 @@ final class GuideDetailView: UIView {
 
 extension GuideDetailView {
     func setUI() {
-        backgroundColor = .bg0
+        backgroundColor = .white
     }
     
     func setHierarchy() {

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/ViewController/ExperienceDetailViewController.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/ViewController/ExperienceDetailViewController.swift
@@ -53,12 +53,21 @@ extension ExperienceDetailViewController {
     }
     
     func setAddTarget() {
-        experienceDetailView.navigationBar.backButton.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
+        experienceDetailView.navigationBar.backButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+        experienceDetailView.gifButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
     }
     
     @objc
-    func backButtonTapped() {
-        self.navigationController?.popViewController(animated: true)
+    func buttonTapped(_ sender: UIButton) {
+        switch sender {
+        case experienceDetailView.navigationBar.backButton:
+            self.navigationController?.popViewController(animated: true)
+        case experienceDetailView.gifButton:
+            let nav = ExperienceGiftViewController()
+            self.navigationController?.pushViewController(nav, animated: true)
+        default:
+            break
+        }
     }
     
     func setDelegate() {

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/ViewController/ExperienceDetailViewController.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/ViewController/ExperienceDetailViewController.swift
@@ -44,7 +44,11 @@ extension ExperienceDetailViewController {
 
     func bindViewModel() {
         viewModel.observeExperienceDetail { [weak self] experienceDetail in
+            guard let experienceDetail = experienceDetail else { return }
+            self?.experienceDetailView.configureExperienceView(model: experienceDetail)
+            self?.experienceDetailView.explainDetailView.configureExplainView(model: experienceDetail)
             self?.explainTableView.reloadData()
+            self?.experienceDetailView.imageCollectionView.reloadData()
         }
     }
     
@@ -71,11 +75,15 @@ extension ExperienceDetailViewController: UICollectionViewDelegate {
 
 extension ExperienceDetailViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 6
+        return viewModel.experienceDetail?.giftImgURL.count ?? 0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = ExperienceImageCollectionViewCell.dequeueReusableCell(collectionView: imageCollectionView, indexPath: indexPath)
+        guard let data = viewModel.experienceDetail else {
+            return cell
+        }
+        cell.configureCell(img: data.giftImgURL[indexPath.row])
         return cell
     }
 }

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/ViewController/ExperienceDetailViewController.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/ViewController/ExperienceDetailViewController.swift
@@ -29,13 +29,18 @@ final class ExperienceDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setNavigationBar()
+        setUI()
         setDelegate()
         bindViewModel()
+        setAddTarget()
     }
 }
 
 extension ExperienceDetailViewController {
+    
+    func setUI() {
+        self.navigationController?.navigationBar.isHidden = true
+    }
 
     func bindViewModel() {
         viewModel.observeExperienceDetail { [weak self] experienceDetail in
@@ -43,24 +48,12 @@ extension ExperienceDetailViewController {
         }
     }
     
-    func setNavigationBar() {
-        let backButton = UIBarButtonItem(image: ImageLiterals.Icon.arrow_left,
-                                         style: .plain,
-                                         target: self,
-                                         action: #selector(backButtonTapped))
-        navigationItem.leftBarButtonItem?.width = 30.0
-        navigationItem.leftBarButtonItem = backButton
-        navigationItem.leftBarButtonItem?.tintColor = .black
-        
-        let label = UILabel()
-        label.text = I18N.Common.appTitle
-        label.font = .boldSystemFont(ofSize: 20)
-        navigationItem.titleView = label
+    func setAddTarget() {
+        experienceDetailView.navigationBar.backButton.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
     }
     
     @objc
     func backButtonTapped() {
-        print("✅")
         self.navigationController?.popViewController(animated: true)
     }
     

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/ViewController/ExperienceDetailViewController.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/ViewController/ExperienceDetailViewController.swift
@@ -9,12 +9,19 @@ import UIKit
 
 final class ExperienceDetailViewController: UIViewController {
     
+    // MARK: - Properties
+    
+    private let viewModel = ExperienceDetailViewModel()
+    
+    // MARK: - UI Components
+    
     private let experienceDetailView = ExperienceDetailView()
     private lazy var imageCollectionView = experienceDetailView.imageCollectionView
     private lazy var explainTableView = experienceDetailView.explainDetailView.explainTableView
     
+    // MARK: - Life Cycles
+    
     override func loadView() {
-        super.loadView()
         
         view = experienceDetailView
     }
@@ -24,10 +31,18 @@ final class ExperienceDetailViewController: UIViewController {
         
         setNavigationBar()
         setDelegate()
+        bindViewModel()
     }
 }
 
 extension ExperienceDetailViewController {
+
+    func bindViewModel() {
+        viewModel.observeExperienceDetail { [weak self] experienceDetail in
+            self?.explainTableView.reloadData()
+        }
+    }
+    
     func setNavigationBar() {
         let backButton = UIBarButtonItem(image: ImageLiterals.Icon.arrow_left,
                                          style: .plain,
@@ -80,7 +95,12 @@ extension ExperienceDetailViewController: UICollectionViewDelegateFlowLayout {
 
 extension ExperienceDetailViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 110
+        switch indexPath.row {
+        case 3:
+            return 20
+        default:
+            return 110
+        }
     }
 }
 
@@ -91,6 +111,15 @@ extension ExperienceDetailViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = ExplainTableViewCell.dequeueReusableCell(tableView: explainTableView)
+        switch indexPath.row {
+        case 3:
+            cell.configureLastCell()
+        default:
+            guard let explanation = viewModel.experienceDetail?.explanation[indexPath.row] else {
+                return cell
+            }
+            cell.configureCell(model: explanation)
+        }
         return cell
     }
 }

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/ViewModel/ExperienceDetailViewModel.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/ViewModel/ExperienceDetailViewModel.swift
@@ -1,0 +1,72 @@
+//
+//  ExperienceDetailViewModel.swift
+//  ShallWe
+//
+//  Created by 고아라 on 2/10/24.
+//
+
+import UIKit
+
+protocol ExperienceDetailViewModelInputs {
+    func experienceDetail(giftId: Int)
+}
+
+protocol ExperienceDetailViewModelOutputs {
+    var experienceDetail: ExperienceDetailResponseDto? { get }
+}
+
+protocol ExperienceDetailViewModelType {
+    var inputs: ExperienceDetailViewModelInputs { get }
+    var outputs: ExperienceDetailViewModelOutputs { get }
+}
+
+class ExperienceDetailObservable<T> {
+    typealias Observer = (T) -> Void
+    var observer: Observer?
+    
+    func observe(observer: @escaping Observer) {
+        self.observer = observer
+    }
+    
+    func emit(_ value: T) {
+        observer?(value)
+    }
+}
+
+final class ExperienceDetailViewModel: ExperienceDetailViewModelInputs, ExperienceDetailViewModelOutputs, ExperienceDetailViewModelType {
+    
+    private var experienceDetailObservable = ExperienceDetailObservable<ExperienceDetailResponseDto?>()
+    
+    var experienceDetail: ExperienceDetailResponseDto? {
+        didSet {
+            experienceDetailObservable.emit(experienceDetail)
+        }
+    }
+    
+    func observeExperienceDetail(_ observer: @escaping ExperienceDetailObservable<ExperienceDetailResponseDto?>.Observer) {
+        experienceDetailObservable.observe(observer: observer)
+    }
+    
+    var inputs: ExperienceDetailViewModelInputs { return self }
+    var outputs: ExperienceDetailViewModelOutputs { return self }
+    
+    init(){
+        getExperienceDetail(giftId: 1)
+    }
+    
+    func experienceDetail(giftId: Int) {
+        self.getExperienceDetail(giftId: giftId)
+    }
+}
+
+extension ExperienceDetailViewModel {
+    
+    func getExperienceDetail(giftId: Int) {
+        ExperienceAPI.shared.getExperienceDetail(giftId: giftId) { [weak self] response in
+            guard (response?.status) != nil else { return }
+            guard self != nil else { return }
+            guard let data = response?.data else { return }
+            self?.experienceDetail = data
+        }
+    }
+}


### PR DESCRIPTION
## 💌 작업한 내용
- MVVM 패턴으로 리팩토링
- 경험 상세페이지 API 연결


## 💭 PR POINT
- Rx 안써보고 싶어서 옵져버랑 didSet 사용해서 했는데 빡세게 코리 부탁드립니다!!!


## 📷 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/ShallWeProject/ShallWeProject_iOS/assets/79412889/d837a5e5-7509-4f36-a17d-c43d9d709071" width ="250">|

## 💐 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #41 
