### PR TITLE
[Feat] #45 - 경험선물 뷰 API 연결

### DIFF
--- a/ShallWe/ShallWe.xcodeproj/project.pbxproj
+++ b/ShallWe/ShallWe.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 		A4998BCA2B778C6B00883017 /* ExperienceDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4998BC92B778C6B00883017 /* ExperienceDetailViewModel.swift */; };
 		A4998BCD2B77967B00883017 /* ExperienceTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4998BCC2B77967B00883017 /* ExperienceTarget.swift */; };
 		A4998BD02B77981600883017 /* ExperienceAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4998BCF2B77981600883017 /* ExperienceAPI.swift */; };
+		A4998BEF2B7D322500883017 /* ReservationDateDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4998BEE2B7D322500883017 /* ReservationDateDto.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -310,12 +311,11 @@
 		A431BE5D2B1AFAF90049C126 /* UICollectionViewRegisterable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICollectionViewRegisterable.swift; sourceTree = "<group>"; };
 		A431BE5F2B1AFB160049C126 /* UITableViewRegisterable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITableViewRegisterable.swift; sourceTree = "<group>"; };
 		A431BE762B1EEF4A0049C126 /* ExperienceGiftViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceGiftViewController.swift; sourceTree = "<group>"; };
-		A4998BC32B760B2400883017 /* ConfigDev.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ConfigDev.xcconfig; sourceTree = "<group>"; };
-		A4998BC42B760B9800883017 /* ConfigRelease.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ConfigRelease.xcconfig; sourceTree = "<group>"; };
 		A4998BC62B761CB200883017 /* ExperienceDetailResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceDetailResponseDto.swift; sourceTree = "<group>"; };
 		A4998BC92B778C6B00883017 /* ExperienceDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceDetailViewModel.swift; sourceTree = "<group>"; };
 		A4998BCC2B77967B00883017 /* ExperienceTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceTarget.swift; sourceTree = "<group>"; };
 		A4998BCF2B77981600883017 /* ExperienceAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceAPI.swift; sourceTree = "<group>"; };
+		A4998BEE2B7D322500883017 /* ReservationDateDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservationDateDto.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1124,6 +1124,7 @@
 			isa = PBXGroup;
 			children = (
 				A4998BC62B761CB200883017 /* ExperienceDetailResponseDto.swift */,
+				A4998BEE2B7D322500883017 /* ReservationDateDto.swift */,
 			);
 			path = Experience;
 			sourceTree = "<group>";
@@ -1382,6 +1383,7 @@
 				9515EF6E2B58640700C4E1AA /* FAQViewController.swift in Sources */,
 				0322139A2B1B6ED300FF5CF1 /* HomeExperienceCell.swift in Sources */,
 				0322136F2B15F8CF00FF5CF1 /* TabBarItem.swift in Sources */,
+				A4998BEF2B7D322500883017 /* ReservationDateDto.swift in Sources */,
 				0322139C2B1B8B3100FF5CF1 /* HomeHeaderView.swift in Sources */,
 				95748DCE2B25FAB4004157E0 /* LoginViewController.swift in Sources */,
 				9515EF802B5C63C100C4E1AA /* AccountSettingsViewController.swift in Sources */,

--- a/ShallWe/ShallWe.xcodeproj/project.pbxproj
+++ b/ShallWe/ShallWe.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 		A4998BCD2B77967B00883017 /* ExperienceTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4998BCC2B77967B00883017 /* ExperienceTarget.swift */; };
 		A4998BD02B77981600883017 /* ExperienceAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4998BCF2B77981600883017 /* ExperienceAPI.swift */; };
 		A4998BEF2B7D322500883017 /* ReservationDateDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4998BEE2B7D322500883017 /* ReservationDateDto.swift */; };
+		A4998BF42B7DCC5C00883017 /* ExperienceGiftViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4998BF32B7DCC5B00883017 /* ExperienceGiftViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -316,6 +317,7 @@
 		A4998BCC2B77967B00883017 /* ExperienceTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceTarget.swift; sourceTree = "<group>"; };
 		A4998BCF2B77981600883017 /* ExperienceAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceAPI.swift; sourceTree = "<group>"; };
 		A4998BEE2B7D322500883017 /* ReservationDateDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservationDateDto.swift; sourceTree = "<group>"; };
+		A4998BF32B7DCC5B00883017 /* ExperienceGiftViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceGiftViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1080,6 +1082,7 @@
 			children = (
 				A431BE7E2B24B0B10049C126 /* Cell */,
 				A431BE752B1EEDD10049C126 /* View */,
+				A4998BF22B7DCC4000883017 /* ViewModel */,
 				A431BE742B1EEDC50049C126 /* ViewController */,
 			);
 			path = ExperienceGift;
@@ -1151,6 +1154,14 @@
 				A4998BCF2B77981600883017 /* ExperienceAPI.swift */,
 			);
 			path = Experience;
+			sourceTree = "<group>";
+		};
+		A4998BF22B7DCC4000883017 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				A4998BF32B7DCC5B00883017 /* ExperienceGiftViewModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1301,6 +1312,7 @@
 				A4998BD02B77981600883017 /* ExperienceAPI.swift in Sources */,
 				A42C33672B416AE300C4B477 /* ExperienceGiftView.swift in Sources */,
 				A431BE552B1A24F90049C126 /* (null) in Sources */,
+				A4998BF42B7DCC5C00883017 /* ExperienceGiftViewModel.swift in Sources */,
 				95748DDE2B358190004157E0 /* ProfileEntryView.swift in Sources */,
 				9515EF682B5421AE00C4E1AA /* TermsDetailsPopUpViewController.swift in Sources */,
 				9515EF662B51600800C4E1AA /* AgreementOfTermsView.swift in Sources */,

--- a/ShallWe/ShallWe.xcodeproj/project.pbxproj
+++ b/ShallWe/ShallWe.xcodeproj/project.pbxproj
@@ -166,8 +166,11 @@
 		A4998BCA2B778C6B00883017 /* ExperienceDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4998BC92B778C6B00883017 /* ExperienceDetailViewModel.swift */; };
 		A4998BCD2B77967B00883017 /* ExperienceTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4998BCC2B77967B00883017 /* ExperienceTarget.swift */; };
 		A4998BD02B77981600883017 /* ExperienceAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4998BCF2B77981600883017 /* ExperienceAPI.swift */; };
-		A4998BEF2B7D322500883017 /* ReservationDateDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4998BEE2B7D322500883017 /* ReservationDateDto.swift */; };
+		A4998BEF2B7D322500883017 /* ReservationDateResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4998BEE2B7D322500883017 /* ReservationDateResponseDto.swift */; };
 		A4998BF42B7DCC5C00883017 /* ExperienceGiftViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4998BF32B7DCC5B00883017 /* ExperienceGiftViewModel.swift */; };
+		A4CBBCB32B8255BB00D55085 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CBBCB22B8255BB00D55085 /* CustomTextField.swift */; };
+		A4CBBCC02B83CB7500D55085 /* ReservationUserRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CBBCBF2B83CB7500D55085 /* ReservationUserRequestDto.swift */; };
+		A4CBBCC22B83CB8100D55085 /* ReservationUserResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CBBCC12B83CB8100D55085 /* ReservationUserResponseDto.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -316,8 +319,11 @@
 		A4998BC92B778C6B00883017 /* ExperienceDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceDetailViewModel.swift; sourceTree = "<group>"; };
 		A4998BCC2B77967B00883017 /* ExperienceTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceTarget.swift; sourceTree = "<group>"; };
 		A4998BCF2B77981600883017 /* ExperienceAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceAPI.swift; sourceTree = "<group>"; };
-		A4998BEE2B7D322500883017 /* ReservationDateDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservationDateDto.swift; sourceTree = "<group>"; };
+		A4998BEE2B7D322500883017 /* ReservationDateResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservationDateResponseDto.swift; sourceTree = "<group>"; };
 		A4998BF32B7DCC5B00883017 /* ExperienceGiftViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperienceGiftViewModel.swift; sourceTree = "<group>"; };
+		A4CBBCB22B8255BB00D55085 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
+		A4CBBCBF2B83CB7500D55085 /* ReservationUserRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservationUserRequestDto.swift; sourceTree = "<group>"; };
+		A4CBBCC12B83CB8100D55085 /* ReservationUserResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservationUserResponseDto.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1072,6 +1078,7 @@
 		A42C32632B30359900C4B477 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				A4CBBCB22B8255BB00D55085 /* CustomTextField.swift */,
 				A42C32652B3040FA00C4B477 /* ExperienceLetterView.swift */,
 			);
 			path = View;
@@ -1127,7 +1134,9 @@
 			isa = PBXGroup;
 			children = (
 				A4998BC62B761CB200883017 /* ExperienceDetailResponseDto.swift */,
-				A4998BEE2B7D322500883017 /* ReservationDateDto.swift */,
+				A4998BEE2B7D322500883017 /* ReservationDateResponseDto.swift */,
+				A4CBBCBF2B83CB7500D55085 /* ReservationUserRequestDto.swift */,
+				A4CBBCC12B83CB8100D55085 /* ReservationUserResponseDto.swift */,
 			);
 			path = Experience;
 			sourceTree = "<group>";
@@ -1322,6 +1331,8 @@
 				A431BE772B1EEF4A0049C126 /* ExperienceGiftViewController.swift in Sources */,
 				A4998BCA2B778C6B00883017 /* ExperienceDetailViewModel.swift in Sources */,
 				A42C33692B416B3E00C4B477 /* TimeCollectionViewCell.swift in Sources */,
+				A4CBBCB32B8255BB00D55085 /* CustomTextField.swift in Sources */,
+				A4CBBCC02B83CB7500D55085 /* ReservationUserRequestDto.swift in Sources */,
 				A431BE582B1A25180049C126 /* (null) in Sources */,
 				0345806D2B288104002DDEBA /* HomeExperienceViewModel.swift in Sources */,
 				0350E26F2B76187F00F3EA69 /* TokenManager.swift in Sources */,
@@ -1375,6 +1386,7 @@
 				95748DD22B25FF6D004157E0 /* LoginView.swift in Sources */,
 				032213892B1B2ADC00FF5CF1 /* BaseView.swift in Sources */,
 				95748DD82B2D9D86004157E0 /* SignUpCompletionViewController.swift in Sources */,
+				A4CBBCC22B83CB8100D55085 /* ReservationUserResponseDto.swift in Sources */,
 				032213B52B241B3100FF5CF1 /* HomeView.swift in Sources */,
 				A4998BCD2B77967B00883017 /* ExperienceTarget.swift in Sources */,
 				954E45BC2B20AEBE00D12242 /* AuthHeaderView.swift in Sources */,
@@ -1395,7 +1407,7 @@
 				9515EF6E2B58640700C4E1AA /* FAQViewController.swift in Sources */,
 				0322139A2B1B6ED300FF5CF1 /* HomeExperienceCell.swift in Sources */,
 				0322136F2B15F8CF00FF5CF1 /* TabBarItem.swift in Sources */,
-				A4998BEF2B7D322500883017 /* ReservationDateDto.swift in Sources */,
+				A4998BEF2B7D322500883017 /* ReservationDateResponseDto.swift in Sources */,
 				0322139C2B1B8B3100FF5CF1 /* HomeHeaderView.swift in Sources */,
 				95748DCE2B25FAB4004157E0 /* LoginViewController.swift in Sources */,
 				9515EF802B5C63C100C4E1AA /* AccountSettingsViewController.swift in Sources */,

--- a/ShallWe/ShallWe/Data/Experience/ExperienceDetailResponseDto.swift
+++ b/ShallWe/ShallWe/Data/Experience/ExperienceDetailResponseDto.swift
@@ -10,12 +10,12 @@ struct ExperienceDetailResponseDto: Codable {
     let title, subtitle: String
     let price: Int
     let explanation: [Explanation]
-    let description, location: String
+    let description, note, location: String
     let experienceGiftID: Int
 
     enum CodingKeys: String, CodingKey {
         case giftImgURL = "giftImgUrl"
-        case title, subtitle, price, explanation, description, location
+        case title, subtitle, price, explanation, description, note, location
         case experienceGiftID = "experienceGiftId"
     }
 }

--- a/ShallWe/ShallWe/Data/Experience/ReservationDateDto.swift
+++ b/ShallWe/ShallWe/Data/Experience/ReservationDateDto.swift
@@ -1,0 +1,18 @@
+//
+//  ReservationDateDto.swift
+//  ShallWe
+//
+//  Created by 고아라 on 2/15/24.
+//
+
+import Foundation
+
+struct ReservationDateDto: Codable {
+    let reservationID: Int
+    let status, time: String
+
+    enum CodingKeys: String, CodingKey {
+        case reservationID = "reservationId"
+        case status, time
+    }
+}

--- a/ShallWe/ShallWe/Data/Experience/ReservationDateResponseDto.swift
+++ b/ShallWe/ShallWe/Data/Experience/ReservationDateResponseDto.swift
@@ -1,5 +1,5 @@
 //
-//  ReservationDateDto.swift
+//  ReservationDateResponseDto.swift
 //  ShallWe
 //
 //  Created by 고아라 on 2/15/24.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct ReservationDateDto: Codable {
+struct ReservationDateResponseDto: Codable {
     let reservationID: Int
     let status, time: String
 

--- a/ShallWe/ShallWe/Data/Experience/ReservationUserRequestDto.swift
+++ b/ShallWe/ShallWe/Data/Experience/ReservationUserRequestDto.swift
@@ -1,0 +1,22 @@
+//
+//  ReservationUserRequestDto.swift
+//  ShallWe
+//
+//  Created by 고아라 on 2/20/24.
+//
+
+import Foundation
+
+struct ReservationUserRequestDto: Codable {
+    let experienceGiftID, persons: Int
+    let date: String
+    let time: String
+    let phoneNumber: String
+    let imageURL: String
+    let invitationComment: String
+
+    enum CodingKeys: String, CodingKey {
+        case experienceGiftID = "experienceGiftId"
+        case persons, date, time, phoneNumber, imageURL, invitationComment
+    }
+}

--- a/ShallWe/ShallWe/Data/Experience/ReservationUserResponseDto.swift
+++ b/ShallWe/ShallWe/Data/Experience/ReservationUserResponseDto.swift
@@ -1,0 +1,34 @@
+//
+//  ReservationUserResponseDto.swift
+//  ShallWe
+//
+//  Created by 고아라 on 2/20/24.
+//
+
+import Foundation
+
+struct ReservationUserResponseDto: Codable {
+    let id, senderID, ownerID: Int
+    let sender: String
+    let persons: Int
+    let date, time: String
+    let experienceGiftID: Int
+    let receiver, phoneNumber, invitationImageURL, invitationComment: String
+    let reservationStatus: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case senderID = "senderId"
+        case ownerID = "ownerId"
+        case sender, persons, date, time
+        case experienceGiftID = "experienceGiftId"
+        case receiver, phoneNumber, invitationImageURL, invitationComment, reservationStatus
+    }
+}
+
+extension ReservationUserResponseDto {
+    
+    static func reservationUserInitValue() -> ReservationUserResponseDto {
+        return ReservationUserResponseDto(id: 0, senderID: 0, ownerID: 0, sender: "", persons: 0, date: "", time: "", experienceGiftID: 0, receiver: "", phoneNumber: "", invitationImageURL: "", invitationComment: "", reservationStatus: "")
+    }
+}

--- a/ShallWe/ShallWe/Global/Extension/String+.swift
+++ b/ShallWe/ShallWe/Global/Extension/String+.swift
@@ -21,6 +21,12 @@ extension String {
         return true
     }
     
+    func isValidPhoneNumber() -> Bool {
+        let phoneNumberRegex = #"^\d{4}$"#
+        let phoneNumberTest = NSPredicate(format: "SELF MATCHES %@", phoneNumberRegex)
+        return phoneNumberTest.evaluate(with: self)
+    }
+    
     func size(OfFont font: UIFont) -> CGSize {
         let size = (self as NSString).size(withAttributes: [.font: font])
         let buffer = 0.2

--- a/ShallWe/ShallWe/Network/API/Experience/ExperienceAPI.swift
+++ b/ShallWe/ShallWe/Network/API/Experience/ExperienceAPI.swift
@@ -19,6 +19,7 @@ final class ExperienceAPI {
     
     public private(set) var experienceDetailData: GeneralResponse<ExperienceDetailResponseDto>?
     public private(set) var reservationDateData: GeneralResponse<[ReservationDateResponseDto]>?
+    public private(set) var reservationUserData: GeneralResponse<ReservationUserResponseDto>?
     
     func getExperienceDetail(giftId: Int,
                              completion: @escaping(GeneralResponse<ExperienceDetailResponseDto>?) -> Void) {
@@ -43,21 +44,41 @@ final class ExperienceAPI {
     func getReservationDate(giftId: Int,
                             date: String,
                             completion: @escaping(GeneralResponse<[ReservationDateResponseDto]>?) -> Void) {
-       experienceProvider.request(.getReservationDate(giftId: giftId, date: date)) { [weak self] result in
-           guard let self else { return }
-           switch result {
-           case .success(let response):
-               do {
-                   self.reservationDateData = try response.map(GeneralResponse<[ReservationDateResponseDto]>?.self)
-                   guard let reservationDateData = self.reservationDateData else { return }
-                   completion(reservationDateData)
-               } catch let err {
-                   print(err.localizedDescription)
-               }
-           case .failure(let err):
-               print(err.localizedDescription)
-               completion(nil)
-           }
-       }
-   }
+        experienceProvider.request(.getReservationDate(giftId: giftId, date: date)) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let response):
+                do {
+                    self.reservationDateData = try response.map(GeneralResponse<[ReservationDateResponseDto]>?.self)
+                    guard let reservationDateData = self.reservationDateData else { return }
+                    completion(reservationDateData)
+                } catch let err {
+                    print(err.localizedDescription)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
+    
+    func postReservationUser(param: ReservationUserRequestDto,
+                             completion: @escaping(GeneralResponse<ReservationUserResponseDto>?) -> Void) {
+        experienceProvider.request(.postReservationUser(param: param)) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let response):
+                do {
+                    self.reservationUserData = try response.map(GeneralResponse<ReservationUserResponseDto>?.self)
+                    guard let reservationUserData = self.reservationUserData else { return }
+                    completion(reservationUserData)
+                } catch let err {
+                    print(err.localizedDescription)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
 }

--- a/ShallWe/ShallWe/Network/API/Experience/ExperienceAPI.swift
+++ b/ShallWe/ShallWe/Network/API/Experience/ExperienceAPI.swift
@@ -18,7 +18,7 @@ final class ExperienceAPI {
     private init() {}
     
     public private(set) var experienceDetailData: GeneralResponse<ExperienceDetailResponseDto>?
-    public private(set) var reservationDateData: GeneralResponse<[ReservationDateDto]>?
+    public private(set) var reservationDateData: GeneralResponse<[ReservationDateResponseDto]>?
     
     func getExperienceDetail(giftId: Int,
                              completion: @escaping(GeneralResponse<ExperienceDetailResponseDto>?) -> Void) {
@@ -42,13 +42,13 @@ final class ExperienceAPI {
     
     func getReservationDate(giftId: Int,
                             date: String,
-                            completion: @escaping(GeneralResponse<[ReservationDateDto]>?) -> Void) {
+                            completion: @escaping(GeneralResponse<[ReservationDateResponseDto]>?) -> Void) {
        experienceProvider.request(.getReservationDate(giftId: giftId, date: date)) { [weak self] result in
            guard let self else { return }
            switch result {
            case .success(let response):
                do {
-                   self.reservationDateData = try response.map(GeneralResponse<[ReservationDateDto]>?.self)
+                   self.reservationDateData = try response.map(GeneralResponse<[ReservationDateResponseDto]>?.self)
                    guard let reservationDateData = self.reservationDateData else { return }
                    completion(reservationDateData)
                } catch let err {

--- a/ShallWe/ShallWe/Network/API/Experience/ExperienceAPI.swift
+++ b/ShallWe/ShallWe/Network/API/Experience/ExperienceAPI.swift
@@ -18,6 +18,7 @@ final class ExperienceAPI {
     private init() {}
     
     public private(set) var experienceDetailData: GeneralResponse<ExperienceDetailResponseDto>?
+    public private(set) var reservationDateData: GeneralResponse<[ReservationDateDto]>?
     
     func getExperienceDetail(giftId: Int,
                              completion: @escaping(GeneralResponse<ExperienceDetailResponseDto>?) -> Void) {
@@ -38,4 +39,25 @@ final class ExperienceAPI {
             }
         }
     }
+    
+    func getReservationDate(giftId: Int,
+                            date: String,
+                            completion: @escaping(GeneralResponse<[ReservationDateDto]>?) -> Void) {
+       experienceProvider.request(.getReservationDate(giftId: giftId, date: date)) { [weak self] result in
+           guard let self else { return }
+           switch result {
+           case .success(let response):
+               do {
+                   self.reservationDateData = try response.map(GeneralResponse<[ReservationDateDto]>?.self)
+                   guard let reservationDateData = self.reservationDateData else { return }
+                   completion(reservationDateData)
+               } catch let err {
+                   print(err.localizedDescription)
+               }
+           case .failure(let err):
+               print(err.localizedDescription)
+               completion(nil)
+           }
+       }
+   }
 }

--- a/ShallWe/ShallWe/Network/APIService/Experience/ExperienceTarget.swift
+++ b/ShallWe/ShallWe/Network/APIService/Experience/ExperienceTarget.swift
@@ -11,6 +11,7 @@ import Moya
 
 enum ExperienceTarget {
     case getExperienceDetail(experienceGiftId: Int)
+    case getReservationDate(giftId: Int, date: String)
 }
 
 extension ExperienceTarget: BaseTargetType {
@@ -21,12 +22,16 @@ extension ExperienceTarget: BaseTargetType {
             let path = URLConstant.experienceDetails
                 .replacingOccurrences(of: "{ExperienceGiftId}", with: String(experienceGiftId))
             return path
+        case .getReservationDate(giftId: let giftId, date: let date):
+            return URLConstant.reservationDate
         }
     }
     
     var method: Moya.Method {
         switch self {
         case .getExperienceDetail:
+            return .get
+        case .getReservationDate:
             return .get
         }
     }
@@ -35,6 +40,9 @@ extension ExperienceTarget: BaseTargetType {
         switch self {
         case .getExperienceDetail:
             return .requestPlain
+        case .getReservationDate(giftId: let giftId, date: let date):
+            return .requestParameters(parameters: ["giftId": giftId, "date": date],
+                                                  encoding: URLEncoding.default)
         }
     }
     

--- a/ShallWe/ShallWe/Network/APIService/Experience/ExperienceTarget.swift
+++ b/ShallWe/ShallWe/Network/APIService/Experience/ExperienceTarget.swift
@@ -12,6 +12,7 @@ import Moya
 enum ExperienceTarget {
     case getExperienceDetail(experienceGiftId: Int)
     case getReservationDate(giftId: Int, date: String)
+    case postReservationUser(param: ReservationUserRequestDto)
 }
 
 extension ExperienceTarget: BaseTargetType {
@@ -24,6 +25,8 @@ extension ExperienceTarget: BaseTargetType {
             return path
         case .getReservationDate(giftId: let giftId, date: let date):
             return URLConstant.reservationDate
+        case .postReservationUser(param: _):
+            return URLConstant.reservationUser
         }
     }
     
@@ -33,6 +36,8 @@ extension ExperienceTarget: BaseTargetType {
             return .get
         case .getReservationDate:
             return .get
+        case .postReservationUser:
+            return .post
         }
     }
     
@@ -43,6 +48,8 @@ extension ExperienceTarget: BaseTargetType {
         case .getReservationDate(giftId: let giftId, date: let date):
             return .requestParameters(parameters: ["giftId": giftId, "date": date],
                                                   encoding: URLEncoding.default)
+        case .postReservationUser(let param):
+            return .requestJSONEncodable(param)
         }
     }
     

--- a/ShallWe/ShallWe/Network/Base/URLConstant.swift
+++ b/ShallWe/ShallWe/Network/Base/URLConstant.swift
@@ -21,6 +21,7 @@ enum URLConstant {
     static let reservationUser = "/api/v1/reservations/user"
     static let reservationValidTime = "/api/v1/reservations/validTimes"
     static let reservationGiftID = "/api/v1/reservations/giftId"
+    static let reservationDate = "/api/v1/reservations/date"
     
     // MemoryPhotos
     

--- a/ShallWe/ShallWe/Presentation/Auth/Views/AuthCompletionView.swift
+++ b/ShallWe/ShallWe/Presentation/Auth/Views/AuthCompletionView.swift
@@ -134,14 +134,15 @@ final class AuthCompletionView: BaseView {
             $0.horizontalEdges.equalToSuperview().inset(20)
         }
     }
+    
+    override func setAddTarget() {
+        homeButton.addTarget(self, action: #selector(homeButtonDidTap), for: .touchUpInside)
+    }
 }
 
 // MARK: - Extensions
 
 extension AuthCompletionView {
-    func setAddTarget() {
-        homeButton.addTarget(self, action: #selector(homeButtonDidTap), for: .touchUpInside)
-    }
     
     // MARK: Actions
     

--- a/ShallWe/ShallWe/Presentation/Common/Base/BaseView.swift
+++ b/ShallWe/ShallWe/Presentation/Common/Base/BaseView.swift
@@ -22,6 +22,7 @@ class BaseView: UIView {
         setStyle()
         setLayout()
         setDelegate()
+        setAddTarget()
     }
     
     override func removeFromSuperview() {
@@ -37,6 +38,7 @@ class BaseView: UIView {
     func setLayout() {}
     /// View 의 Delegate 을 set 합니다.
     func setDelegate() {}
+    func setAddTarget() {}
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/ShallWe/ShallWe/Presentation/Common/Components/CustomNavigationBar.swift
+++ b/ShallWe/ShallWe/Presentation/Common/Components/CustomNavigationBar.swift
@@ -10,6 +10,10 @@ import UIKit
 import Then
 import SnapKit
 
+protocol NavigationBarProtocol {
+    func backButtonTapped()
+}
+
 class CustomNavigationBar: BaseView {
     
     // MARK: - UI Components
@@ -21,6 +25,8 @@ class CustomNavigationBar: BaseView {
     private lazy var titleLabel = UILabel()
 
     // MARK: - Properties
+    
+    var delegate: NavigationBarProtocol?
     
     var isLogoViewIncluded: Bool {
         get { !logoView.isHidden }
@@ -96,5 +102,17 @@ class CustomNavigationBar: BaseView {
             $0.leading.equalToSuperview().inset(15)
             $0.centerY.equalToSuperview()
         }
+    }
+    
+    override func setAddTarget() {
+        backButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+    }
+}
+
+extension CustomNavigationBar {
+    
+    @objc
+    func buttonTapped() {
+        delegate?.backButtonTapped()
     }
 }

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/ExperienceDetailView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/ExperienceDetailView.swift
@@ -14,7 +14,7 @@ final class ExperienceDetailView: UIView {
     // MARK: - UI Components
     
     let explainDetailView = ExplainDetailView()
-    private let guideDetailView = GuideDetailView()
+    let guideDetailView = GuideDetailView()
     
     let navigationBar: CustomNavigationBar = {
         let nav = CustomNavigationBar()

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/ExperienceDetailView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/ExperienceDetailView.swift
@@ -115,7 +115,8 @@ final class ExperienceDetailView: UIView {
     lazy var gifButton: UIButton = {
         let button = UIButton()
         button.setImage(ImageLiterals.Icon.gift, for: .normal)
-        button.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 15)
+        button.setImage(ImageLiterals.Icon.gift, for: .highlighted)
+        button.imageEdgeInsets.right = 8
         button.setTitle(I18N.ExperienceDetail.giftButton, for: .normal)
         button.setTitleColor(.bg0, for: .normal)
         button.titleLabel?.font = .fontGuide(.B00_14)

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/ExperienceDetailView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/ExperienceDetailView.swift
@@ -13,6 +13,7 @@ final class ExperienceDetailView: UIView {
     
     // MARK: - UI Components
     
+    private let segmentWidth = Int((SizeLiterals.Screen.screenWidth - 18) / 2)
     let explainDetailView = ExplainDetailView()
     let guideDetailView = GuideDetailView()
     
@@ -85,7 +86,7 @@ final class ExperienceDetailView: UIView {
         
         for (index, title) in [I18N.ExperienceDetail.segementTitle1, I18N.ExperienceDetail.segementTitle2].enumerated() {
             segment.insertSegment(withTitle: title, at: index, animated: true)
-            segment.setWidth((UIScreen.main.bounds.width - 14) / 2, forSegmentAt: index)
+            segment.setWidth(SizeLiterals.Screen.screenWidth / 2, forSegmentAt: index)
         }
         
         let normalAttributes: [NSAttributedString.Key: Any] = [
@@ -216,7 +217,7 @@ private extension ExperienceDetailView {
         
         underLineView.snp.makeConstraints {
             $0.top.equalTo(segmentControl.snp.bottom)
-            $0.leading.equalTo(segmentControl.snp.leading).offset(9)
+            $0.leading.equalTo(segmentControl.snp.leading).offset(7 + (segmentWidth - 156) / 2)
             $0.width.equalTo(156)
             $0.height.equalTo(2)
         }
@@ -259,7 +260,7 @@ private extension ExperienceDetailView {
     
     @objc
     func changeSegmentedControlLinePosition(_ segment: UISegmentedControl) {
-        let leadingDistance = Int(183 * CGFloat(segment.selectedSegmentIndex) + (174 - self.underLineView.bounds.width) * 0.5)
+        let leadingDistance = Int(7 + (segmentWidth - 156) / 2 + segmentWidth * segmentControl.selectedSegmentIndex)
         UIView.animate(withDuration: 0.2, animations: {
             self.underLineView.snp.updateConstraints { $0.leading.equalTo(self.segmentControl.snp.leading).offset(leadingDistance) }
             self.layoutIfNeeded()

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/GuideDetailView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/View/GuideDetailView.swift
@@ -15,7 +15,6 @@ final class GuideDetailView: UIView {
     
     private let noteTitle: UILabel = {
         let label = UILabel()
-        label.text = I18N.ExperienceDetail.noteTitle
         label.textColor = .black
         label.font = .fontGuide(.B00_12)
         return label
@@ -23,10 +22,10 @@ final class GuideDetailView: UIView {
     
     private let noteLabel: UILabel = {
         let label = UILabel()
-        label.text = "· 선물 시 호스트 연락처를 카카오톡으로 보내드립니다.\n· 예약 확정 시 환불이 불가합니다.\n· 예약 시간에 맞추어 늦지 않게 도착해 주시기 바랍니다.\n· 주차는 가능하나, 기계식이라 SUV는 주차가 불가합니다(소울, 레이 동급 차량 불가).\n· 홈클래스로 진행되는 점 참고 부탁드립니다."
         label.textColor = .black
         label.font = .fontGuide(.R00_12)
         label.numberOfLines = 0
+        label.textAlignment = .left
         return label
     }()
     
@@ -80,7 +79,8 @@ final class GuideDetailView: UIView {
     }
 }
 
-extension GuideDetailView {
+private extension GuideDetailView {
+    
     func setUI() {
         backgroundColor = .white
     }
@@ -122,5 +122,18 @@ extension GuideDetailView {
             $0.leading.equalTo(cancelTitle.snp.leading)
             $0.width.equalTo(343)
         }
+    }
+}
+
+extension GuideDetailView {
+    
+    func configureGuideView(model: ExperienceDetailResponseDto) {
+        let noteList = model.note.split(separator: "\n")
+        var noteListLabel = ""
+        for i in 1..<noteList.count {
+            noteListLabel.append(noteList[i].description + "\n")
+        }
+        noteTitle.text = noteList[0].description
+        noteLabel.text = noteListLabel
     }
 }

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/ViewController/ExperienceDetailViewController.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/ViewController/ExperienceDetailViewController.swift
@@ -64,7 +64,7 @@ extension ExperienceDetailViewController {
         case experienceDetailView.navigationBar.backButton:
             self.navigationController?.popViewController(animated: true)
         case experienceDetailView.gifButton:
-            let nav = ExperienceGiftViewController()
+            let nav = ExperienceGiftViewController(viewModel: self.viewModel)
             self.navigationController?.pushViewController(nav, animated: true)
         default:
             break

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/ViewController/ExperienceDetailViewController.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/ViewController/ExperienceDetailViewController.swift
@@ -54,21 +54,13 @@ extension ExperienceDetailViewController {
     }
     
     func setAddTarget() {
-        experienceDetailView.navigationBar.backButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
         experienceDetailView.gifButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
     }
     
     @objc
     func buttonTapped(_ sender: UIButton) {
-        switch sender {
-        case experienceDetailView.navigationBar.backButton:
-            self.navigationController?.popViewController(animated: true)
-        case experienceDetailView.gifButton:
-            let nav = ExperienceGiftViewController(viewModel: self.viewModel)
-            self.navigationController?.pushViewController(nav, animated: true)
-        default:
-            break
-        }
+        let nav = ExperienceGiftViewController(viewModel: self.viewModel)
+        self.navigationController?.pushViewController(nav, animated: true)
     }
     
     func setDelegate() {
@@ -76,6 +68,7 @@ extension ExperienceDetailViewController {
         imageCollectionView.dataSource = self
         explainTableView.delegate = self
         explainTableView.dataSource = self
+        experienceDetailView.navigationBar.delegate = self
     }
 }
 
@@ -132,5 +125,12 @@ extension ExperienceDetailViewController: UITableViewDataSource {
             cell.configureCell(model: explanation)
         }
         return cell
+    }
+}
+
+extension ExperienceDetailViewController: NavigationBarProtocol {
+    
+    func backButtonTapped() {
+        self.navigationController?.popViewController(animated: true)
     }
 }

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/ViewController/ExperienceDetailViewController.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceDetail/ViewController/ExperienceDetailViewController.swift
@@ -47,6 +47,7 @@ extension ExperienceDetailViewController {
             guard let experienceDetail = experienceDetail else { return }
             self?.experienceDetailView.configureExperienceView(model: experienceDetail)
             self?.experienceDetailView.explainDetailView.configureExplainView(model: experienceDetail)
+            self?.experienceDetailView.guideDetailView.configureGuideView(model: experienceDetail)
             self?.explainTableView.reloadData()
             self?.experienceDetailView.imageCollectionView.reloadData()
         }

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/Cell/TimeCollectionViewCell.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/Cell/TimeCollectionViewCell.swift
@@ -53,7 +53,7 @@ private extension TimeCollectionViewCell {
 
 extension TimeCollectionViewCell {
     
-    func configureCell(model: ReservationDateDto) {
+    func configureCell(model: ReservationDateResponseDto) {
         let timeString = model.time
         let components = timeString.components(separatedBy: ":")
         if let hour = components.first {

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/Cell/TimeCollectionViewCell.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/Cell/TimeCollectionViewCell.swift
@@ -13,7 +13,6 @@ final class TimeCollectionViewCell: UICollectionViewCell, UICollectionViewRegist
     
     let timeLabel: UILabel = {
         let label = UILabel()
-        label.text = "13시"
         label.textColor = .gray4
         label.font = .fontGuide(.M00_14)
         label.textAlignment = .center
@@ -39,7 +38,8 @@ final class TimeCollectionViewCell: UICollectionViewCell, UICollectionViewRegist
     }
 }
 
-extension TimeCollectionViewCell {
+private extension TimeCollectionViewCell {
+    
     func setHierarchy() {
         addSubview(timeLabel)
     }
@@ -47,6 +47,17 @@ extension TimeCollectionViewCell {
     func setLayout() {
         timeLabel.snp.makeConstraints {
             $0.edges.equalToSuperview()
+        }
+    }
+}
+
+extension TimeCollectionViewCell {
+    
+    func configureCell(model: ReservationDateDto) {
+        let timeString = model.time
+        let components = timeString.components(separatedBy: ":")
+        if let hour = components.first {
+            timeLabel.text = "\(hour)시"
         }
     }
 }

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/View/ExperienceGiftView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/View/ExperienceGiftView.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import SnapKit
 import FSCalendar
+import Kingfisher
 
 protocol CalendarDelegate: AnyObject {
     func leftButtonTapped()
@@ -254,7 +255,8 @@ final class ExperienceGiftView: UIView {
     }
 }
 
-extension ExperienceGiftView {
+private extension ExperienceGiftView {
+    
     func setUI() {
         backgroundColor = .white
     }
@@ -426,5 +428,20 @@ extension ExperienceGiftView {
             break
         }
     }
+    
+    func formatNumber(_ number: Int) -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        return numberFormatter.string(from: NSNumber(value: number)) ?? "\(number)"
+    }
 }
 
+extension ExperienceGiftView {
+    
+    func configureGiftView(model: ExperienceDetailResponseDto) {
+        giftImage.kf.setImage(with: URL(string: model.giftImgURL[0]))
+        giftTitle.text = model.subtitle
+        giftSubTitle.text = model.title
+        giftPriceLabel.text = "\(formatNumber(model.price))원"
+    }
+}

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/View/ExperienceGiftView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/View/ExperienceGiftView.swift
@@ -79,7 +79,7 @@ final class ExperienceGiftView: UIView {
     
     private let giftTitle: UILabel = {
         let label = UILabel()
-        label.textColor = .black0
+        label.textColor = .black
         label.font = .fontGuide(.B00_12)
         return label
     }()

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/View/ExperienceGiftView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/View/ExperienceGiftView.swift
@@ -139,7 +139,7 @@ final class ExperienceGiftView: UIView {
         return button
     }()
     
-    private lazy var personCountLabel: UILabel = {
+    lazy var personCountLabel: UILabel = {
         let label = UILabel()
         label.text = String(self.personCount)
         label.textAlignment = .center

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/View/ExperienceGiftView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/View/ExperienceGiftView.swift
@@ -64,7 +64,6 @@ final class ExperienceGiftView: UIView {
     private let giftImage: UIImageView = {
         let image = UIImageView()
         image.contentMode = .scaleAspectFill
-        image.image = UIImage(named: "example")
         image.clipsToBounds = true
         image.layer.cornerRadius = 10
         return image
@@ -80,7 +79,6 @@ final class ExperienceGiftView: UIView {
     
     private let giftTitle: UILabel = {
         let label = UILabel()
-        label.text = "[성수] 인기베이킹 클래스"
         label.textColor = .black0
         label.font = .fontGuide(.B00_12)
         return label
@@ -88,7 +86,6 @@ final class ExperienceGiftView: UIView {
     
     private let giftSubTitle: UILabel = {
         let label = UILabel()
-        label.text = "기념일 레터링 케이크\n사지 말고 함께 만들어요"
         label.textColor = .black
         label.font = .fontGuide(.M00_14)
         label.setLineSpacing(lineSpacing: 2.3)
@@ -99,7 +96,6 @@ final class ExperienceGiftView: UIView {
     
     let giftPriceLabel: UILabel = {
         let label = UILabel()
-        label.text = "75,000원"
         label.textColor = .main
         label.font = .fontGuide(.B00_14)
         return label
@@ -131,6 +127,7 @@ final class ExperienceGiftView: UIView {
         button.setImage(ImageLiterals.Icon.minus, for: .normal)
         button.backgroundColor = .bg4
         button.layer.cornerRadius = 10
+        button.isEnabled = false
         return button
     }()
     

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/View/ExperienceGiftView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/View/ExperienceGiftView.swift
@@ -217,7 +217,8 @@ final class ExperienceGiftView: UIView {
     lazy var giftButton: UIButton = {
         let button = UIButton()
         button.setImage(ImageLiterals.Icon.gift, for: .normal)
-        button.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 15)
+        button.setImage(ImageLiterals.Icon.gift, for: .highlighted)
+        button.imageEdgeInsets.right = 8
         button.setTitle(I18N.ExperienceDetail.giftButton, for: .normal)
         button.setTitleColor(.bg0, for: .normal)
         button.titleLabel?.font = .fontGuide(.B00_14)

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewController/ExperienceGiftViewController.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewController/ExperienceGiftViewController.swift
@@ -91,6 +91,7 @@ extension ExperienceGiftViewController {
         timeCollectionView.delegate = self
         experienceGiftView.calendarDelegate = self
         experienceGiftView.calendarView.delegate = self
+        experienceGiftView.navigationBar.delegate = self
     }
     
     func bindViewModel() {
@@ -189,5 +190,12 @@ extension ExperienceGiftViewController: FSCalendarDelegate {
     
     func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
         experienceGiftView.monthLabel.text = self.dateFormatter.string(from: calendar.currentPage)
+    }
+}
+
+extension ExperienceGiftViewController: NavigationBarProtocol {
+    
+    func backButtonTapped() {
+        self.navigationController?.popViewController(animated: true)
     }
 }

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewController/ExperienceGiftViewController.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewController/ExperienceGiftViewController.swift
@@ -22,12 +22,13 @@ final class ExperienceGiftViewController: UIViewController {
     private var selectedDate: String = ""
     private var selectedTime: String = ""
     
-    private let viewModel = ExperienceDetailViewModel()
+    private let detailViewModel = ExperienceDetailViewModel()
+    private let giftViewModel = ExperienceGiftViewModel()
     
     // MARK: - UI Components
     
     private let experienceGiftView = ExperienceGiftView()
-    private lazy var collectionView = experienceGiftView.timeCollectionView
+    private lazy var timeCollectionView = experienceGiftView.timeCollectionView
     
     private lazy var dateFormatter: DateFormatter = {
         let df = DateFormatter()
@@ -73,16 +74,21 @@ extension ExperienceGiftViewController {
     }
     
     func setDelegate() {
-        collectionView.dataSource = self
-        collectionView.delegate = self
+        timeCollectionView.dataSource = self
+        timeCollectionView.delegate = self
         experienceGiftView.calendarDelegate = self
         experienceGiftView.calendarView.delegate = self
     }
     
     func bindViewModel() {
-        viewModel.observeExperienceDetail { [weak self] experienceDetail in
+        detailViewModel.observeExperienceDetail { [weak self] experienceDetail in
             guard let experienceDetail = experienceDetail else { return }
             self?.experienceGiftView.configureGiftView(model: experienceDetail)
+        }
+        
+        giftViewModel.observeExperienceGift { [weak self] experienceGift in
+            guard let experienceGift = experienceGift else { return }
+            self?.experienceGiftView.timeCollectionView.reloadData()
         }
     }
     
@@ -119,11 +125,13 @@ extension ExperienceGiftViewController: UICollectionViewDelegate {
 
 extension ExperienceGiftViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 4
+        return giftViewModel.reservationDate?.count ?? 0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = TimeCollectionViewCell.dequeueReusableCell(collectionView: collectionView, indexPath: indexPath)
+        let cell = TimeCollectionViewCell.dequeueReusableCell(collectionView: timeCollectionView, indexPath: indexPath)
+        guard let data = giftViewModel.reservationDate else { return cell }
+        cell.configureCell(model: data[indexPath.item])
         return cell
     }
 }

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewController/ExperienceGiftViewController.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewController/ExperienceGiftViewController.swift
@@ -119,8 +119,9 @@ extension ExperienceGiftViewController: UICollectionViewDelegate {
         if let cell = collectionView.cellForItem(at: indexPath) as? TimeCollectionViewCell {
             cell.timeLabel.backgroundColor = .point
             cell.timeLabel.textColor = .white
-            if let timeText = cell.timeLabel.text {
-                self.selectedTime = timeText
+            let components = cell.timeLabel.text?.components(separatedBy: CharacterSet.decimalDigits.inverted)
+            if let timeHour = components?.first {
+                giftViewModel.giftTimeInfo(time: timeHour)
             }
         }
         
@@ -169,7 +170,8 @@ extension ExperienceGiftViewController: CalendarDelegate {
                 self.navigationController?.pushViewController(nav, animated: true)
             })
         } else {
-            let nav = ExperienceLetterViewController()
+            giftViewModel.giftMemberInfo(member: Int(experienceGiftView.personCountLabel.text ?? "") ?? 1)
+            let nav = ExperienceLetterViewController(viewModel: self.giftViewModel)
             self.navigationController?.pushViewController(nav, animated: true)
         }
     }

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewController/ExperienceGiftViewController.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewController/ExperienceGiftViewController.swift
@@ -22,7 +22,7 @@ final class ExperienceGiftViewController: UIViewController {
     private var selectedDate: String = ""
     private var selectedTime: String = ""
     
-    private let detailViewModel = ExperienceDetailViewModel()
+    private let detailViewModel: ExperienceDetailViewModel
     private let giftViewModel = ExperienceGiftViewModel()
     
     // MARK: - UI Components
@@ -37,6 +37,13 @@ final class ExperienceGiftViewController: UIViewController {
         return df
     }()
     
+    // MARK: - Initializer
+
+    init(viewModel: ExperienceDetailViewModel) {
+        self.detailViewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
     // MARK: - Life Cycles
     
     override func loadView() {
@@ -50,6 +57,11 @@ final class ExperienceGiftViewController: UIViewController {
         setUI()
         setDelegate()
         bindViewModel()
+    }
+    
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 }
 
@@ -81,10 +93,8 @@ extension ExperienceGiftViewController {
     }
     
     func bindViewModel() {
-        detailViewModel.observeExperienceDetail { [weak self] experienceDetail in
-            guard let experienceDetail = experienceDetail else { return }
-            self?.experienceGiftView.configureGiftView(model: experienceDetail)
-        }
+        guard let experienceDetail = detailViewModel.experienceDetail else { return }
+        self.experienceGiftView.configureGiftView(model: experienceDetail)
         
         giftViewModel.observeExperienceGift { [weak self] experienceGift in
             guard let experienceGift = experienceGift else { return }
@@ -168,8 +178,9 @@ extension ExperienceGiftViewController: CalendarDelegate {
 extension ExperienceGiftViewController: FSCalendarDelegate {
     func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
         let components = Calendar.current.dateComponents([.year, .month, .day], from: date)
-        if let selectedMonth = components.month, let selectedDay = components.day {
-            self.selectedDate = "\(selectedMonth)월 \(selectedDay)일"
+        if let selectedYear = components.year, let selectedMonth = components.month, let selectedDay = components.day {
+            self.selectedDate = "\(selectedYear)-\(String(format: "%02d", selectedMonth))-\(String(format: "%02d", selectedDay))"
+            giftViewModel.reservationDate(giftId: 1, date: self.selectedDate)
         }
     }
     

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewController/ExperienceGiftViewController.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewController/ExperienceGiftViewController.swift
@@ -69,6 +69,7 @@ extension ExperienceGiftViewController {
     
     func setUI() {
         navigationController?.navigationBar.isHidden = true
+        experienceGiftView.calendarView.select(today)
         
         if fromMypage {
             experienceGiftView.navigationBar.titleText = I18N.ExperienceGift.fromMypageNavigationTitle
@@ -97,7 +98,7 @@ extension ExperienceGiftViewController {
         self.experienceGiftView.configureGiftView(model: experienceDetail)
         
         giftViewModel.observeExperienceGift { [weak self] experienceGift in
-            guard let experienceGift = experienceGift else { return }
+            guard experienceGift != nil else { return }
             self?.experienceGiftView.timeCollectionView.reloadData()
         }
     }

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewController/ExperienceGiftViewController.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewController/ExperienceGiftViewController.swift
@@ -22,6 +22,8 @@ final class ExperienceGiftViewController: UIViewController {
     private var selectedDate: String = ""
     private var selectedTime: String = ""
     
+    private let viewModel = ExperienceDetailViewModel()
+    
     // MARK: - UI Components
     
     private let experienceGiftView = ExperienceGiftView()
@@ -37,7 +39,6 @@ final class ExperienceGiftViewController: UIViewController {
     // MARK: - Life Cycles
     
     override func loadView() {
-        super.loadView()
         
         view = experienceGiftView
     }
@@ -47,10 +48,12 @@ final class ExperienceGiftViewController: UIViewController {
         
         setUI()
         setDelegate()
+        bindViewModel()
     }
 }
 
 extension ExperienceGiftViewController {
+    
     func setUI() {
         navigationController?.navigationBar.isHidden = true
         
@@ -74,6 +77,13 @@ extension ExperienceGiftViewController {
         collectionView.delegate = self
         experienceGiftView.calendarDelegate = self
         experienceGiftView.calendarView.delegate = self
+    }
+    
+    func bindViewModel() {
+        viewModel.observeExperienceDetail { [weak self] experienceDetail in
+            guard let experienceDetail = experienceDetail else { return }
+            self?.experienceGiftView.configureGiftView(model: experienceDetail)
+        }
     }
     
     func scrollCurrentPage(isPrev: Bool) {

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewModel/ExperienceGiftViewModel.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewModel/ExperienceGiftViewModel.swift
@@ -12,7 +12,7 @@ protocol ExperienceGiftViewModelInputs {
 }
 
 protocol ExperienceGiftViewModelOutputs {
-    var reservationDate: [ReservationDateDto]? { get }
+    var reservationDate: [ReservationDateResponseDto]? { get }
 }
 
 protocol ExperienceGiftViewModelType {
@@ -35,15 +35,15 @@ class ExperienceGiftObservable<T> {
 
 final class ExperienceGiftViewModel: ExperienceGiftViewModelInputs, ExperienceGiftViewModelOutputs, ExperienceGiftViewModelType {
     
-    private var experienceGiftObservable = ExperienceGiftObservable<[ReservationDateDto]?>()
+    private var experienceGiftObservable = ExperienceGiftObservable<[ReservationDateResponseDto]?>()
     
-    var reservationDate: [ReservationDateDto]? {
+    var reservationDate: [ReservationDateResponseDto]? {
         didSet {
             experienceGiftObservable.emit(reservationDate)
         }
     }
     
-    func observeExperienceGift(_ observer: @escaping ExperienceGiftObservable<[ReservationDateDto]?>.Observer) {
+    func observeExperienceGift(_ observer: @escaping ExperienceGiftObservable<[ReservationDateResponseDto]?>.Observer) {
         experienceGiftObservable.observe(observer: observer)
     }
     

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewModel/ExperienceGiftViewModel.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewModel/ExperienceGiftViewModel.swift
@@ -1,0 +1,72 @@
+//
+//  ExperienceGiftViewModel.swift
+//  ShallWe
+//
+//  Created by 고아라 on 2/15/24.
+//
+
+import UIKit
+
+protocol ExperienceGiftViewModelInputs {
+    func reservationDate(giftId: Int, date: String)
+}
+
+protocol ExperienceGiftViewModelOutputs {
+    var reservationDate: [ReservationDateDto]? { get }
+}
+
+protocol ExperienceGiftViewModelType {
+    var inputs: ExperienceGiftViewModelInputs { get }
+    var outputs: ExperienceGiftViewModelOutputs { get }
+}
+
+class ExperienceGiftObservable<T> {
+    typealias Observer = (T) -> Void
+    var observer: Observer?
+    
+    func observe(observer: @escaping Observer) {
+        self.observer = observer
+    }
+    
+    func emit(_ value: T) {
+        observer?(value)
+    }
+}
+
+final class ExperienceGiftViewModel: ExperienceGiftViewModelInputs, ExperienceGiftViewModelOutputs, ExperienceGiftViewModelType {
+    
+    private var experienceGiftObservable = ExperienceGiftObservable<[ReservationDateDto]?>()
+    
+    var reservationDate: [ReservationDateDto]? {
+        didSet {
+            experienceGiftObservable.emit(reservationDate)
+        }
+    }
+    
+    func observeExperienceGift(_ observer: @escaping ExperienceGiftObservable<[ReservationDateDto]?>.Observer) {
+        experienceGiftObservable.observe(observer: observer)
+    }
+    
+    var inputs: ExperienceGiftViewModelInputs { return self }
+    var outputs: ExperienceGiftViewModelOutputs { return self }
+    
+    init(){
+        getReservationDate(giftId: 1, date: "2024-02-08")
+    }
+    
+    func reservationDate(giftId: Int, date: String) {
+        self.getReservationDate(giftId: giftId, date: date)
+    }
+}
+
+extension ExperienceGiftViewModel {
+    
+    func getReservationDate(giftId: Int,  date: String) {
+        ExperienceAPI.shared.getReservationDate(giftId: giftId, date: date) { [weak self] response in
+            guard (response?.status) != nil else { return }
+            guard self != nil else { return }
+            guard let data = response?.data else { return }
+            self?.reservationDate = data
+        }
+    }
+}

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewModel/ExperienceGiftViewModel.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewModel/ExperienceGiftViewModel.swift
@@ -9,6 +9,8 @@ import UIKit
 
 protocol ExperienceGiftViewModelInputs {
     func reservationDate(giftId: Int, date: String)
+    func giftMemberInfo(member: Int)
+    func giftTimeInfo(time: String)
 }
 
 protocol ExperienceGiftViewModelOutputs {
@@ -37,11 +39,22 @@ final class ExperienceGiftViewModel: ExperienceGiftViewModelInputs, ExperienceGi
     
     private var experienceGiftObservable = ExperienceGiftObservable<[ReservationDateResponseDto]?>()
     
+    // properties
+    
+    private var selectGiftId: Int = 0
+    private var selectMember: Int = 0
+    private var selectDate: String = ""
+    private var selectTime: String = ""
+    
+    // output
+    
     var reservationDate: [ReservationDateResponseDto]? {
         didSet {
             experienceGiftObservable.emit(reservationDate)
         }
     }
+    
+    var reservationUser: ReservationUserResponseDto?
     
     func observeExperienceGift(_ observer: @escaping ExperienceGiftObservable<[ReservationDateResponseDto]?>.Observer) {
         experienceGiftObservable.observe(observer: observer)
@@ -51,11 +64,23 @@ final class ExperienceGiftViewModel: ExperienceGiftViewModelInputs, ExperienceGi
     var outputs: ExperienceGiftViewModelOutputs { return self }
     
     init(){
-        reservationDate(giftId: 1, date: "2024-02-08")
+        self.reservationDate(giftId: 1, date: "2024-02-08")
     }
     
+    // input
+    
     func reservationDate(giftId: Int, date: String) {
+        self.selectGiftId = giftId
+        self.selectDate = date
         self.getReservationDate(giftId: giftId, date: date)
+    }
+    
+    func giftMemberInfo(member: Int) {
+        self.selectMember = member
+    }
+    
+    func giftTimeInfo(time: String) {
+        self.selectTime = time
     }
 }
 

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewModel/ExperienceGiftViewModel.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewModel/ExperienceGiftViewModel.swift
@@ -51,7 +51,7 @@ final class ExperienceGiftViewModel: ExperienceGiftViewModelInputs, ExperienceGi
     var outputs: ExperienceGiftViewModelOutputs { return self }
     
     init(){
-        getReservationDate(giftId: 1, date: "2024-02-08")
+        reservationDate(giftId: 1, date: "2024-02-08")
     }
     
     func reservationDate(giftId: Int, date: String) {

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewModel/ExperienceGiftViewModel.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewModel/ExperienceGiftViewModel.swift
@@ -117,7 +117,7 @@ extension ExperienceGiftViewModel {
     }
     
     func postReservationUser() {
-        let model: ReservationUserRequestDto = ReservationUserRequestDto(experienceGiftID: 17, persons: selectMember, date: "2024-02-21", time: "04:00:00", phoneNumber: phone, imageURL: "", invitationComment: letter)
+        let model: ReservationUserRequestDto = ReservationUserRequestDto(experienceGiftID: selectGiftId, persons: selectMember, date: selectDate, time: selectTime, phoneNumber: phone, imageURL: "", invitationComment: letter)
         ExperienceAPI.shared.postReservationUser(param: model) { [weak self] response in
             guard let statusCode = response?.statusCode else { return }
             guard self != nil else { return }

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewModel/ExperienceGiftViewModel.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceGift/ViewModel/ExperienceGiftViewModel.swift
@@ -73,7 +73,11 @@ final class ExperienceGiftViewModel: ExperienceGiftViewModelInputs, ExperienceGi
     var outputs: ExperienceGiftViewModelOutputs { return self }
     
     init(){
-        self.reservationDate(giftId: 1, date: "2024-02-08")
+        let today = Date()
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        let dateString = dateFormatter.string(from: today)
+        self.reservationDate(giftId: 1, date: dateString)
     }
     
     // input

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceLetter/View/CustomTextField.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceLetter/View/CustomTextField.swift
@@ -1,0 +1,91 @@
+//
+//  CustomTextField.swift
+//  ShallWe
+//
+//  Created by 고아라 on 2/19/24.
+//
+
+import UIKit
+
+final class CustomTextField: UITextField {
+    
+    // MARK: - Properties
+    
+    @frozen
+    enum TextFieldStatus {
+        case normal
+        case correct
+        
+        var borderColor: CGColor? {
+            switch self {
+            case .normal:
+                return UIColor.gray2.cgColor
+            case .correct:
+                return UIColor.bg4.cgColor
+            }
+        }
+        
+        var backgroundColor: UIColor? {
+            switch self {
+            case .normal:
+                return UIColor.gray0
+            case .correct:
+                return UIColor.bg1
+            }
+        }
+    }
+    
+    enum TextFieldType {
+        case name
+        case phone
+    }
+    
+    var textFieldStatus: TextFieldStatus = .normal {
+        didSet {
+            updateBorderColor()
+        }
+    }
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    convenience init(type: TextFieldType, placeHolder: String) {
+        self.init()
+        
+        setUI(type: type, placeHolder: placeHolder)
+    }
+}
+
+// MARK: - Extensions
+
+private extension CustomTextField {
+    func setUI(type: TextFieldType, placeHolder: String) {
+        self.placeholder = "\(placeHolder)"
+        self.setPlaceholderColor(.gray4)
+        self.layer.cornerRadius = 10
+        self.layer.borderColor = UIColor.gray2.cgColor
+        self.layer.borderWidth = 1
+        self.font = .fontGuide(.M00_12)
+        self.backgroundColor = .gray0
+        
+        switch type {
+        case .name:
+            self.setLeftPadding(amount: 14)
+            self.textAlignment = .left
+        case .phone:
+            self.textAlignment = .center
+        }
+    }
+    
+    func updateBorderColor() {
+        self.layer.borderColor = textFieldStatus.borderColor
+        self.backgroundColor = textFieldStatus.backgroundColor
+    }
+}

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceLetter/View/ExperienceLetterView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceLetter/View/ExperienceLetterView.swift
@@ -39,19 +39,7 @@ final class ExperienceLetterView: UIView {
         return label
     }()
     
-    private let senderTextField: UITextField = {
-        let textfield = UITextField()
-        textfield.textColor = .black0
-        textfield.font = .fontGuide(.M00_12)
-        textfield.backgroundColor = .gray0
-        textfield.layer.borderColor = UIColor.gray2.cgColor
-        textfield.layer.borderWidth = 1
-        textfield.layer.cornerRadius = 10
-        textfield.placeholder = I18N.ExperienceLetter.namePlaceholder
-        textfield.setPlaceholderColor(.gray4)
-        textfield.setLeftPadding(amount: 14)
-        return textfield
-    }()
+    let senderTextField = CustomTextField(type: .name, placeHolder: I18N.ExperienceLetter.namePlaceholder)
     
     private let seperatorView2: UIView = {
         let view = UIView()
@@ -82,57 +70,10 @@ final class ExperienceLetterView: UIView {
         return label
     }()
     
-    private let recipientNameTextField: UITextField = {
-        let textfield = UITextField()
-        textfield.textColor = .black0
-        textfield.font = .fontGuide(.M00_12)
-        textfield.backgroundColor = .gray0
-        textfield.layer.borderColor = UIColor.gray2.cgColor
-        textfield.layer.borderWidth = 1
-        textfield.layer.cornerRadius = 10
-        textfield.placeholder = I18N.ExperienceLetter.namePlaceholder
-        textfield.setPlaceholderColor(.gray4)
-        textfield.setLeftPadding(amount: 14)
-        return textfield
-    }()
-    
-    private let phoneFirstText: UITextField = {
-        let textfield = UITextField()
-        textfield.text = I18N.ExperienceLetter.phoneFirstTitle
-        textfield.textColor = .black0
-        textfield.textAlignment = .center
-        textfield.font = .fontGuide(.M00_12)
-        textfield.backgroundColor = .bg1
-        textfield.layer.borderColor = UIColor.bg4.cgColor
-        textfield.layer.borderWidth = 1
-        textfield.layer.cornerRadius = 10
-        textfield.isEnabled = false
-        return textfield
-    }()
-    
-    private let phoneMidText: UITextField = {
-        let textfield = UITextField()
-        textfield.textColor = .black0
-        textfield.textAlignment = .center
-        textfield.font = .fontGuide(.M00_12)
-        textfield.backgroundColor = .gray0
-        textfield.layer.borderColor = UIColor.gray2.cgColor
-        textfield.layer.borderWidth = 1
-        textfield.layer.cornerRadius = 10
-        return textfield
-    }()
-    
-    private let phoneEndText: UITextField = {
-        let textfield = UITextField()
-        textfield.textColor = .black0
-        textfield.textAlignment = .center
-        textfield.font = .fontGuide(.M00_12)
-        textfield.backgroundColor = .gray0
-        textfield.layer.borderColor = UIColor.gray2.cgColor
-        textfield.layer.borderWidth = 1
-        textfield.layer.cornerRadius = 10
-        return textfield
-    }()
+    let recipientNameTextField = CustomTextField(type: .name, placeHolder: I18N.ExperienceLetter.namePlaceholder)
+    let phoneFirstText = CustomTextField(type: .phone, placeHolder: "")
+    let phoneMidText = CustomTextField(type: .phone, placeHolder: "")
+    let phoneEndText = CustomTextField(type: .phone, placeHolder: "")
     
     private let seperatorView3: UIView = {
         let view = UIView()
@@ -211,6 +152,8 @@ extension ExperienceLetterView {
         backgroundColor = .white
         infoIcon.isHidden = true
         infoTitle.isHidden = true
+        phoneFirstText.text = I18N.ExperienceLetter.phoneFirstTitle
+        phoneFirstText.textFieldStatus = .correct
     }
     
     func setDelegate() {

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceLetter/View/ExperienceLetterView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceLetter/View/ExperienceLetterView.swift
@@ -17,7 +17,7 @@ final class ExperienceLetterView: UIView {
     
     // MARK: - UI Components
     
-    private let navigationBar: CustomNavigationBar = {
+    let navigationBar: CustomNavigationBar = {
         let navigationBar = CustomNavigationBar()
         navigationBar.isBackButtonIncluded = true
         navigationBar.isTitleLabelIncluded = true

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceLetter/View/ExperienceLetterView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceLetter/View/ExperienceLetterView.swift
@@ -121,7 +121,8 @@ final class ExperienceLetterView: UIView {
     lazy var giftButton: UIButton = {
         let button = UIButton()
         button.setImage(ImageLiterals.Icon.gift, for: .normal)
-        button.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 15)
+        button.setImage(ImageLiterals.Icon.gift, for: .highlighted)
+        button.imageEdgeInsets.right = 8
         button.setTitle(I18N.ExperienceDetail.giftButton, for: .normal)
         button.setTitleColor(.bg0, for: .normal)
         button.titleLabel?.font = .fontGuide(.B00_14)

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceLetter/View/ExperienceLetterView.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceLetter/View/ExperienceLetterView.swift
@@ -96,7 +96,7 @@ final class ExperienceLetterView: UIView {
         return image
     }()
     
-    private let letterTextView: UITextView = {
+    let letterTextView: UITextView = {
         let textview = UITextView()
         let exampletext = "예시"
         let attributedString = NSAttributedString(string: exampletext, attributes: [

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceLetter/ViewController/ExperienceLetterViewController.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceLetter/ViewController/ExperienceLetterViewController.swift
@@ -59,6 +59,7 @@ extension ExperienceLetterViewController {
         experienceLetterView.phoneFirstText.delegate = self
         experienceLetterView.phoneMidText.delegate = self
         experienceLetterView.phoneEndText.delegate = self
+        experienceLetterView.navigationBar.delegate = self
     }
     
     @objc
@@ -142,5 +143,12 @@ extension ExperienceLetterViewController: UITextFieldDelegate {
     
     func textFieldDidBeginEditing(_ textField: UITextField) {
         textField.becomeFirstResponder()
+    }
+}
+
+extension ExperienceLetterViewController: NavigationBarProtocol {
+    
+    func backButtonTapped() {
+        self.navigationController?.popViewController(animated: true)
     }
 }

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceLetter/ViewController/ExperienceLetterViewController.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceLetter/ViewController/ExperienceLetterViewController.swift
@@ -39,6 +39,7 @@ final class ExperienceLetterViewController: UIViewController {
         setUI()
         setAddTarget()
         setDelegate()
+        setGesture()
     }
 }
 
@@ -62,9 +63,25 @@ extension ExperienceLetterViewController {
     
     @objc
     func buttonTapped() {
+        giftViewModel.giftLetterInfo(letter: experienceLetterView.letterTextView.text ?? "")
+        giftViewModel.postReservationUser()
+        
         let nav = CompleteViewController()
         nav.fromExperience = true
         self.navigationController?.pushViewController(nav, animated: true)
+    }
+    
+    func setGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        view.addGestureRecognizer(tapGesture)
+    }
+    
+    @objc func dismissKeyboard() {
+        if experienceLetterView.phoneMidText.textFieldStatus == .correct
+            && experienceLetterView.phoneEndText.textFieldStatus == .correct {
+            giftViewModel.giftPhoneInfo(phone: "010\(experienceLetterView.phoneMidText.text ?? "")\(experienceLetterView.phoneEndText.text ?? "")")
+        }
+        view.endEditing(true)
     }
     
     func validateTextField(textField: UITextField, isValid: Bool) {
@@ -115,6 +132,10 @@ extension ExperienceLetterViewController: UITextFieldDelegate {
     }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        if experienceLetterView.phoneMidText.textFieldStatus == .correct 
+            && experienceLetterView.phoneEndText.textFieldStatus == .correct {
+            giftViewModel.giftPhoneInfo(phone: "010\(experienceLetterView.phoneMidText.text ?? "")\(experienceLetterView.phoneEndText.text ?? "")")
+        }
         textField.resignFirstResponder()
         return true
     }

--- a/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceLetter/ViewController/ExperienceLetterViewController.swift
+++ b/ShallWe/ShallWe/Presentation/ExperienceScene/ExperienceLetter/ViewController/ExperienceLetterViewController.swift
@@ -9,13 +9,27 @@ import UIKit
 
 final class ExperienceLetterViewController: UIViewController {
     
+    // MARK: - Properties
+    
+    private let giftViewModel: ExperienceGiftViewModel
+    
     // MARK: - UI Components
     
     private let experienceLetterView = ExperienceLetterView()
 
     // MARK: - Life Cycles
     
+    init(viewModel: ExperienceGiftViewModel) {
+        self.giftViewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func loadView() {
+        
         view = experienceLetterView
     }
     
@@ -23,6 +37,8 @@ final class ExperienceLetterViewController: UIViewController {
         super.viewDidLoad()
         
         setUI()
+        setAddTarget()
+        setDelegate()
     }
 }
 
@@ -36,10 +52,74 @@ extension ExperienceLetterViewController {
         experienceLetterView.giftButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
     }
     
+    func setDelegate() {
+        experienceLetterView.recipientNameTextField.delegate = self
+        experienceLetterView.senderTextField.delegate = self
+        experienceLetterView.phoneFirstText.delegate = self
+        experienceLetterView.phoneMidText.delegate = self
+        experienceLetterView.phoneEndText.delegate = self
+    }
+    
     @objc
     func buttonTapped() {
         let nav = CompleteViewController()
         nav.fromExperience = true
         self.navigationController?.pushViewController(nav, animated: true)
+    }
+    
+    func validateTextField(textField: UITextField, isValid: Bool) {
+        if isValid {
+            if let customTextField = textField as? CustomTextField {
+                customTextField.textFieldStatus = .correct
+            }
+        } else {
+            if let customTextField = textField as? CustomTextField {
+                customTextField.textFieldStatus = .normal
+            }
+        }
+    }
+}
+
+
+extension ExperienceLetterViewController: UITextFieldDelegate {
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        let currentText = textField.text ?? ""
+        let newText = (currentText as NSString).replacingCharacters(in: range, with: string)
+        switch textField {
+        case experienceLetterView.recipientNameTextField,experienceLetterView.senderTextField:
+            validateTextField(textField: textField, isValid: newText.isOnlyKorean())
+        case experienceLetterView.phoneFirstText:
+            if newText.count > 3 {
+                return false
+            }
+            validateTextField(textField: textField, isValid: newText == "010")
+        case experienceLetterView.phoneMidText, experienceLetterView.phoneEndText:
+            if newText.count > 4 {
+                return false
+            }
+            validateTextField(textField: textField, isValid: newText.isValidPhoneNumber())
+        default:
+            break
+        }
+        return true
+    }
+    
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        let currentText = textField.text ?? ""
+        if currentText.isEmpty {
+            if let customTextField = textField as? CustomTextField {
+                customTextField.textFieldStatus = .normal
+            }
+        }
+    }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+    
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        textField.becomeFirstResponder()
     }
 }

--- a/ShallWe/ShallWe/Presentation/Mypage/ViewController/MyPageViewController.swift
+++ b/ShallWe/ShallWe/Presentation/Mypage/ViewController/MyPageViewController.swift
@@ -66,9 +66,9 @@ extension MyPageViewController {
 extension MyPageViewController: MypageDelegate {
     
     func editButtonTapped() {
-        let nav = ExperienceGiftViewController()
-        nav.fromMypage = true
-        self.navigationController?.pushViewController(nav, animated: true)
+//        let nav = ExperienceGiftViewController(viewModel: )
+//        nav.fromMypage = true
+//        self.navigationController?.pushViewController(nav, animated: true)
     }
     
     func cancelButtonTapped() {


### PR DESCRIPTION
## 💌 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
-  경험상세뷰 model 수정사항 반영 및 추가 바인딩
- 경험선물뷰 1 경험선물조회 GET 연결
- 경험선물뷰 1 날짜조회 GET 연결
- 경험선물뷰 2 예약추가 POST 연결
- 경험선물뷰 2 텍스트필드 처리
- MVVM으로 리팩토링

## 💭 PR POINT

<!-- 덧붙이고 싶은 내용이 있다면! -->
- post가 1가지 조건으로 1번밖에 테스트가 불가능해서.. 서버와 대면으로 만날때 해보면 매우 좋을듯..


## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/ShallWeProject/ShallWeProject_iOS/assets/79412889/b7845de1-f850-4331-a4cf-3d8a10d19fe7" width ="250">|

## 💐 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #45 
